### PR TITLE
CRI-O CVE-2022-0811 mitigation

### DIFF
--- a/content/blog/2022/03/cri-o-cve-mitigation.md
+++ b/content/blog/2022/03/cri-o-cve-mitigation.md
@@ -1,0 +1,63 @@
+---
+title: CRI-O CVE-2022-0811 Mitigation
+authors:
+- José Guilherme Vanz
+date: 2022-03-29
+---
+
+Recently a severe [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0811)
+in the CRI-O container engine come to public. The flaw in CRI-O allows bad
+actors to gain root access and run arbitrary code in the host machine.
+
+A [fix](https://github.com/cri-o/cri-o/releases/tag/v1.23.2) for the issue is
+already available and you should update your cluster to avoid any headache in
+the future. But if you cannot do that right away, use Kubewarden to mitigate the impact of
+this issue. It's possible to prevent pods with `sysctl` configuration
+to run in the cluster with the policy `sysctl-psp` available in the [Policy
+Hub](https://hub.kubewarden.io/).
+
+The policy configuration to block all sysctl-related configuration for a pod is detailed below:
+
+```yaml
+apiVersion: policies.kubewarden.io/v1alpha2
+kind: ClusterAdmissionPolicy
+metadata:
+  name: mitigate-crio-cve
+spec:
+  module: registry://ghcr.io/kubewarden/policies/sysctl-psp:v0.1.7
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: false
+  settings:
+    forbiddenSysctls:
+    - "*"
+```
+
+This will not allow pods that have kernel parameters defined to run. It's important to
+remember that this is **not** a fix for the issue, but a temporary mitigation. You must update your CRI-O version as
+soon as possible.
+
+You can test the solution using the pod definition from [this Sysdig blogpost](https://sysdig.com/blog/cve-2022-0811-cri-o/):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctl-set
+spec:
+  securityContext:
+   sysctls:
+   - name: kernel.shm_rmid_forced
+     value: "1+kernel.core_pattern=|/var/lib/containers/storage/overlay/3ef1281bce79865599f673b476957be73f994d17c15109d2b6a426711cf753e6/diff/malicious.sh #"
+  containers:
+  - name: alpine
+    image: alpine:latest
+
+```
+
+Once the`sysctl-psp` policy is running, you will not be able to deploy the pod.


### PR DESCRIPTION
## Description

Adds a blog post showing how users can use Kubewarden to mitigate the CRI-O CVE-2022-0811 blocking Kernel parameters configuration.

Fix #69 

