### PR TITLE
Fix navigation links - remove relURL from href

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,7 +19,7 @@
 
       <ul class="menu">
         {{ range . }}
-        <li><a href="{{ .URL | relURL }}" class="btn no-bg">{{ .Name }}</a></li>
+        <li><a href="{{ .URL }}" target="_blank" class="btn no-bg">{{ .Name }}</a></li>
         {{ end }}
         <!-- github  -->
         <li><a href="{{ $.Site.Params.github }}" class="btn"><img src="/images/icon-github.svg"><span>Github</span></a>


### PR DESCRIPTION
## Description
Fix #75 
Currently the navigation links are adding the prefix `https://kubewarden.io` to every link, causing each to fail.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:
- Run `hugo server -D`
- Use navigation links 
