### PR TITLE
Fix github button hover color - remove thematic break

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -143,6 +143,10 @@ section.wrap p {
   .main-menu a:focus {
     background: none; /* Remove background from off-canvas styling */
     color: var(--primary-color);
+
+    &.github {
+      background: var(--primary-color);
+    }
   }
 }
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -83,7 +83,6 @@ date: 2021-04-16T13:28:46+02:00
   </p>
 
 </section>
-<hr />
 
 <section class="get-started">
   <div class="white">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,7 +22,7 @@
         <li><a href="{{ .URL }}" target="_blank" class="btn no-bg">{{ .Name }}</a></li>
         {{ end }}
         <!-- github  -->
-        <li><a href="{{ $.Site.Params.github }}" class="btn"><img src="/images/icon-github.svg"><span>Github</span></a>
+        <li><a href="{{ $.Site.Params.github }}" class="btn github"><img src="/images/icon-github.svg"><span>Github</span></a>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
## Description
This fixes the issue of the Github button in the main nav disappearing on hover and removes the thematic break above the "Get Started" section.
<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #77 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:
`hugo server -D`

View the server at `localhost:1313`
<!--
```shell
cp <to_package_directory>
go test
```
-->