### PR TITLE
Show blog in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ This is the source repository for the https://www.kubewarden.io website.
 
 It is done with [Hugo](https://gohugo.io) and the Rancher Labs
 [project theme](https://github.com/rancherlabs/projects-theme).
+
+## Local development
+
+``` console
+$ git submodule init && git submodule update
+$ hugo server -D
+```

--- a/config.toml
+++ b/config.toml
@@ -68,3 +68,9 @@ home = ["HTML", "RSS", "Algolia"]
     name = "Twitter"
     url = "https://twitter.com/kubewarden"
     weight = -80
+
+  [[menu.main]]
+    identifier = "blog"
+    name = "Blog"
+    url = "https://kubewarden.io/blog"
+    weight = -70


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
partially fixes https://github.com/kubewarden/kubewarden.io/issues/76

With this, the blog entry is part of the header again:

![blog](https://user-images.githubusercontent.com/2196685/163993494-5244a1e5-3226-4f70-aadd-fa01a452d468.png)
