### PR TITLE
Fix conflicting styles with ul and li elements in blog

### DIFF
--- a/assets/sass/blog.scss
+++ b/assets/sass/blog.scss
@@ -35,6 +35,17 @@ section.wrap {
     line-height: 2.8rem;
   }
 
+  ul {
+    display: block;
+    padding-left: revert;
+  }
+  
+  li {
+    display: list-item;
+    border-bottom: none;
+    padding: revert;
+  }
+
   time {
     font-size: 1.5rem;
   }


### PR DESCRIPTION
## Description
There were some conflicting styles comeing from the project theme css that caused the unordered lists and list items to be hard to read.

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #95 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

1. Run `hugo serve`
2. Go to `https://localhost:1313/blog/2022/02/multiplatform-kubewarden/`
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information
![good](https://user-images.githubusercontent.com/40806497/167470107-8f456f32-413b-4301-9dad-f080f3505989.png)

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
