### PR TITLE
Fix link to the PSP migration documentation.

### DIFF
--- a/content/blog/2022/05/psp-migration-docs.md
+++ b/content/blog/2022/05/psp-migration-docs.md
@@ -3,17 +3,18 @@ title: "Have you migrated your Kubernetes PodSecurityPolicy?"
 authors:
 - José Guilherme Vanz
 date: 2022-05-12
+lastmod: 2022-05-19
 ---
 
 If you use a version of Kubernetes (< v1.24) that supports the deprecated PodSecurityPolicy (a.k.a PSP), you would be
 wondering what to do after the Kubernetes v1.25 version when the PSP will be removed.
-With this in mind, the Kuberwarden team wrote a [documentation](https://docs.kubewarden.io/psp-migration.html)
+With this in mind, the Kuberwarden team wrote a [documentation](https://docs.kubewarden.io/tasksDir/psp-migration)
 to help users migrate away from PSPs to Kuberwarden policies.
 
 As you know, the original Pod Security Policies had many configuration knobs.
 The Kubewarden team created a series of policies that offer a 100% feature
 parity with all the soon to be dropped Pod Security Policies.
-This section of our [documentation](https://docs.kubewarden.io/psp-migration.html)
+This section of our [documentation](https://docs.kubewarden.io/tasksDir/psp-migration)
 highlights all these policies and guides you through their recommended settings.
 
 On this topic, do you know our helm chart provides a [flag](https://github.com/kubewarden/helm-charts/tree/main/charts/kubewarden-defaults#configuration)


### PR DESCRIPTION
The blog post about PSP migration has link to the old PSP migration documentation page. It has the link for the page before the docusaurus migration. This commit updates the link to the right one.
