### PR TITLE
Fix links: remove obsolete numbering

### DIFF
--- a/content/blog/2021/09/towards-a-universal-policy-platform.md
+++ b/content/blog/2021/09/towards-a-universal-policy-platform.md
@@ -122,7 +122,7 @@ the `kwctl run` command.
 If you are already familiar with Kubewarden, you will notice the developer
 workflow stays the same, regardless of the programming language used.
 
-All these steps are described in detail inside of our [documentation](https://docs.kubewarden.io/writing-policies/rego/01-intro.html).
+All these steps are described in detail inside of our [documentation](https://docs.kubewarden.io/writing-policies/rego/intro.html).
 
 ## Enforcing a Rego Policy
 

--- a/content/blog/2021/11/deep-dive-into-policy-logging.md
+++ b/content/blog/2021/11/deep-dive-into-policy-logging.md
@@ -20,9 +20,9 @@ internally.
 
 Kubewarden has defined  a contract between policies (guests) and the host (Kubewarden) for
 performing [policy settings
-validation](https://docs.kubewarden.io/writing-policies/spec/02-settings.html), [policy
-validation](https://docs.kubewarden.io/writing-policies/spec/03-validating-policies.html), [policy
-mutation](https://docs.kubewarden.io/writing-policies/spec/04-mutating-policies.html) and now,
+validation](https://docs.kubewarden.io/writing-policies/spec/settings.html), [policy
+validation](https://docs.kubewarden.io/writing-policies/spec/validating-policies.html), [policy
+mutation](https://docs.kubewarden.io/writing-policies/spec/mutating-policies.html) and now,
 logging.
 
 The waPC interface used for logging is therefore a contract, because once you have built a policy,
@@ -220,6 +220,6 @@ This functionality closes the gap on logging/tracing, given the freedom that the
 collector provides to us in terms of flexibility of what to do with this logs and traces.
 
 You can read more about Kubewarden's integration with OpenTelemetry in [our
-documentation](https://docs.kubewarden.io/operator-manual/telemetry/opentelemetry/01-quickstart.html).
+documentation](https://docs.kubewarden.io/operator-manual/telemetry/opentelemetry/quickstart.html).
 
 But this is a big enough topic on its own worth a future blog post. Stay logged!

--- a/content/blog/2022/05/monitor-mode.md
+++ b/content/blog/2022/05/monitor-mode.md
@@ -64,7 +64,7 @@ about the consequences deploying new policies will have on their
 existing operations.
 
 You can read more about the Monitor mode in [our
-documentation](https://docs.kubewarden.io/operator-manual/monitor-mode/01-intro.html).
+documentation](https://docs.kubewarden.io/operator-manual/monitor-mode/intro.html).
 
 Stay tuned for more and thrilling features in the UX side of
 Kubewarden!


### PR DESCRIPTION
## Description

Existing links point to `Page Not Found`, removed numbering to fix it.

