### PR TITLE
Add blog post about certificate verification

### DIFF
--- a/content/blog/2022/11/sigstore-certificate-verification.md
+++ b/content/blog/2022/11/sigstore-certificate-verification.md
@@ -1,0 +1,108 @@
+---
+title: Support for sigstore certificate signing
+authors:
+- Flavio Castelli
+date: 2022-11-30
+---
+
+Secure supply chain is one of the hottest topics right now. Many organizations
+are implementing strategies to verify the provenance of their software starting from
+the development phase up to the deployment in production.
+
+[Sigstore](https://sigstore.dev/) is an open source project that makes incredibly
+easy to sign and verify assets. Lots of open source projects and organizations
+are using it to sign and verify their container images, system packages and any kind
+of binary artifact.
+It's no secret we are Sigstore enthusiasts.
+
+We are using Sigstore to sign and verify our whole
+software stack, we are maintainers of the official [Rust SDK](https://github.com/sigstore/sigstore-rs),
+we are [exposing its capabilities to policy authors](https://docs.kubewarden.io/writing-policies/spec/host-capabilities/signature-verifier-policies)
+and, finally, we are providing a
+[Kubewarden policy](https://github.com/kubewarden/verify-image-signatures/) that
+can be used to verify the container images allowed into a Kubernetes cluster.
+
+Sigstore supports different signing mechanisms. Today we're happy to announce
+that Kubewarden is now exposing all the primitives required to verify signatures
+produced with user-defined certificates. At signature time, these certificate
+can be read from the local file system or, more interesting, could be used by
+an hardware token (like a Yubikey) or by a KMS.
+
+With this addition, Kubewarden can verify these the signatures produced in these
+ways.
+
+## Required versions
+
+Certificate based verification is available starting from these releases:
+
+* kwctl: TODO
+* Policy Server: TODO
+* "verify-image-signatures" policy: TODO
+
+## Certificate verification in action
+
+Certificate based verification is now available to all our policy authors. However
+there's no need to write any code, since we've extended our
+[`verify-image-signatures` policy](https://github.com/kubewarden/verify-image-signatures/)
+to support this new type of verification.
+
+The following snippet shows how to ensure that all the container images coming
+from `registry.example.org/project-safety` have been signed by both Alice and Bob:
+
+```yaml
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: verify-image-signatures
+spec:
+  module: ghcr.io/kubewarden/policies/verify-image-signatures:v0.1.7
+  rules:
+  - apiGroups: ["", "apps", "batch"]
+    apiVersions: ["v1"]
+    resources: ["pods", "deployments", "statefulsets", "replicationcontrollers", "jobs", "cronjobs"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: true
+  settings:
+    signatures:
+    - image: "registry.example.org/project-safety/*"
+      certificate:
+      - |
+        -----BEGIN CERTIFICATE-----
+        Alice's cert
+        -----END CERTIFICATE-----
+      - |
+        -----BEGIN CERTIFICATE-----
+        Bob's cert
+        -----END CERTIFICATE-----
+      certificateChain:
+      - |
+        -----BEGIN CERTIFICATE-----
+        <intermediate cert>
+        -----END CERTIFICATE-----
+      - |
+        -----BEGIN CERTIFICATE-----
+        <root CA>
+        -----END CERTIFICATE-----
+      requireRekorBundle: true
+```
+
+This will make sure that images like `registry.example.org/project-safety/micro-svc-shopping-cart:v1.0.0`
+and `registry.example.org/project-safety/micro-svc-search:v1.2.0` are signed
+by Alice and Bob.
+
+## Breaking changes to the "`verify-image-signature`" policy
+
+Starting from version TODO of the "`verify-image-signature`", all the policy settings
+are going to use the [`camelCase`](https://en.wikipedia.org/wiki/Camel_case)
+naming convention.
+
+This means the following configuration keys changed their ID:
+
+* Keyless verification produced by GitHub: `github_actions` &rarr; `githubActions`
+* Keyless verification using a subject prefix:
+  * `url_prefix` &rarr; `urlPrefix`
+  * `keyless_prefix` &rarr; `keylessPrefix`
+
+

--- a/content/blog/2022/11/sigstore-certificate-verification.md
+++ b/content/blog/2022/11/sigstore-certificate-verification.md
@@ -24,7 +24,7 @@ can be used to verify the container images allowed into a Kubernetes cluster.
 
 Sigstore supports different signing mechanisms. Today we're happy to announce
 that Kubewarden is now exposing all the primitives required to verify signatures
-produced with user-defined certificates. At signature time, these certificate
+produced with user-defined certificates. At signature time, these certificates
 can be read from the local file system or, more interesting, could be used by
 an hardware token (like a Yubikey) or by a KMS.
 

--- a/content/blog/2022/11/sigstore-certificate-verification.md
+++ b/content/blog/2022/11/sigstore-certificate-verification.md
@@ -28,7 +28,7 @@ produced with user-defined certificates. At signature time, these certificates
 can be read from the local file system or, more interestingly, could be used by
 a hardware token (like a Yubikey) or by a KMS.
 
-With this addition, Kubewarden can verify these the signatures produced in these
+With this addition, Kubewarden can verify these the signatures produced in those
 ways.
 
 ## Required versions

--- a/content/blog/2022/11/sigstore-certificate-verification.md
+++ b/content/blog/2022/11/sigstore-certificate-verification.md
@@ -25,7 +25,7 @@ can be used to verify the container images allowed into a Kubernetes cluster.
 Sigstore supports different signing mechanisms. Today we're happy to announce
 that Kubewarden is now exposing all the primitives required to verify signatures
 produced with user-defined certificates. At signature time, these certificates
-can be read from the local file system or, more interesting, could be used by
+can be read from the local file system or, more interestingly, could be used by
 an hardware token (like a Yubikey) or by a KMS.
 
 With this addition, Kubewarden can verify these the signatures produced in these

--- a/content/blog/2022/11/sigstore-certificate-verification.md
+++ b/content/blog/2022/11/sigstore-certificate-verification.md
@@ -26,7 +26,7 @@ Sigstore supports different signing mechanisms. Today we're happy to announce
 that Kubewarden is now exposing all the primitives required to verify signatures
 produced with user-defined certificates. At signature time, these certificates
 can be read from the local file system or, more interestingly, could be used by
-an hardware token (like a Yubikey) or by a KMS.
+a hardware token (like a Yubikey) or by a KMS.
 
 With this addition, Kubewarden can verify these the signatures produced in these
 ways.

--- a/content/blog/2022/11/sigstore-certificate-verification.md
+++ b/content/blog/2022/11/sigstore-certificate-verification.md
@@ -18,7 +18,7 @@ It's no secret we are Sigstore enthusiasts.
 We are using Sigstore to sign and verify our whole
 software stack, we are maintainers of the official [Rust SDK](https://github.com/sigstore/sigstore-rs),
 we are [exposing its capabilities to policy authors](https://docs.kubewarden.io/writing-policies/spec/host-capabilities/signature-verifier-policies)
-and, finally, we are providing a
+and, finally, we have been providing a
 [Kubewarden policy](https://github.com/kubewarden/verify-image-signatures/) that
 can be used to verify the container images allowed into a Kubernetes cluster.
 

--- a/content/blog/2022/12/sigstore-certificate-verification.md
+++ b/content/blog/2022/12/sigstore-certificate-verification.md
@@ -2,7 +2,7 @@
 title: Support for sigstore certificate signing
 authors:
 - Flavio Castelli
-date: 2022-11-30
+date: 2022-12-2
 ---
 
 Secure supply chain is one of the hottest topics right now. Many organizations
@@ -35,9 +35,9 @@ ways.
 
 Certificate based verification is available starting from these releases:
 
-* kwctl: TODO
-* Policy Server: TODO
-* "verify-image-signatures" policy: TODO
+* Kubewarden stack: version 1.4.0 or later
+* [verify-image-signatures](https://artifacthub.io/packages/kubewarden/verify-image-signatures/verify-image-signatures)
+policy: version 0.2.0 or later
 
 ## Certificate verification in action
 
@@ -105,4 +105,9 @@ This means the following configuration keys changed their ID:
   * `url_prefix` &rarr; `urlPrefix`
   * `keyless_prefix` &rarr; `keylessPrefix`
 
+## Call for action
 
+That's all for today, it's time to give these changes a try!
+
+Feel free to [reach out to us](https://kubernetes.slack.com/?redir=%2Fmessages%2Fkubewarden)
+if you have any questions or want to share your feedback!

--- a/content/blog/2022/12/sigstore-certificate-verification.md
+++ b/content/blog/2022/12/sigstore-certificate-verification.md
@@ -2,7 +2,7 @@
 title: Support for sigstore certificate signing
 authors:
 - Flavio Castelli
-date: 2022-12-2
+date: 2022-12-05
 ---
 
 Secure supply chain is one of the hottest topics right now. Many organizations


### PR DESCRIPTION
Describe the certificate verification feature.

This fixes https://github.com/kubewarden/kubewarden.io/issues/152

**Important notes:**

* This cannot be merged yet, we have to tag releases of everything
* I think we should do a minor release of the Kubewarden stack. This would make it easier
  to our end users to understand which version of Kubewarden is required to leverage this
  feature. I don't like the current "required versions" section of the document, it's too
  complicated to keep track of everything

