### PR TITLE
Fix community meeting post date.

### DIFF
--- a/content/blog/2022/12/community-meeting.md
+++ b/content/blog/2022/12/community-meeting.md
@@ -2,7 +2,7 @@
 title: Community meeting is coming!
 authors:
 - Olivier Vernin
-date: 2022-12-21
+date: 2022-12-20
 ---
 
 Community meetings have been a recurring demand from different sides and with the new year approaching,


### PR DESCRIPTION
The date of the community meeting post is wrong. Therefore, when the pages are build the post is not rendered. Changing the date and rebuilding the page fix the issue.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>