### PR TITLE
fix: remove link to policy hub

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,8 +41,8 @@ home = ["HTML", "RSS", "Algolia"]
 
   [[menu.main]]
     identifier = "hub"
-    name = "Policy Hub"
-    url = "https://hub.kubewarden.io/"
+    name = "Policies"
+    url = "https://artifacthub.io/packages/search?kind=13&sort=relevance&page=1"
     weight = -130
 
   [[menu.main]]


### PR DESCRIPTION
Remove the link to policy hub from the navigation bar. Replace that with a link to ArtifacHub page that lists all the kubewarden policies.

The navigation bar has now this link: [Policies](https://artifacthub.io/packages/search?kind=13&sort=relevance&page=1). Clicking on the link opens a new browser tab.

![image](https://user-images.githubusercontent.com/22728/213702988-7178a502-8534-4f8b-8291-5209831c1c61.png)

