### PR TITLE
Update cert-manager to 1.11.0

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -106,7 +106,7 @@ date: 2021-04-16T13:28:46+02:00
     <pre>
 <code>
 $ helm repo add kubewarden https://charts.kubewarden.io
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
 $ kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 $ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds
 $ helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller


### PR DESCRIPTION
Rancher 2.7.2 [moved to cert-manager 1.11.0](https://github.com/rancher/rancher/releases/tag/v2.7.2)

We still point to cert-manager 1.5.3 in our docs, which is almost 2 years old.