### PR TITLE
fix: add warning message about psp migration code.

### DIFF
--- a/content/blog/2022/07/psp-migration-script.md
+++ b/content/blog/2022/07/psp-migration-script.md
@@ -5,6 +5,11 @@ authors:
 date: 2022-07-13
 ---
 
+> Warning: the code snippets shown inside of this blog post have become
+> outdated. For up-to-date information checkout
+> [this](https://docs.kubewarden.io/tasksDir/psp-migration) section of the
+> Kubewarden documentation.
+
 As announced in past blog posts, Kubewarden has 100% coverage of the deprecated,
 and soon to be removed, Kubernetes PSPs. If everything goes as expected the PSPs will
 be removed in Kubernetes v1.25 due for release on 23rd August 2022.


### PR DESCRIPTION
## Description

Updates the blog post about the PSP migration script adding a warning about the out of date code snippets in the post. Adding a link to the doc website with the latest documentation.

Fix https://github.com/kubewarden/kubewarden.io/issues/185
