### PR TITLE
Add survey banner to main page

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -174,3 +174,19 @@ footer .project-icons a img {
     background: #fff;
   }
 }
+
+// Survey banner
+
+.survey-container {
+  background-color: var(--dark);
+  padding: 1rem;
+  text-align: center;
+  position: relative;
+}
+
+.survey-content {
+  display: block;
+  color: var(--light);
+  font-size: 1.6rem;
+  width: 100%;
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,6 +32,7 @@
 			</iframe>
 		</noscript>
 	{{ end }}
+	{{ partial "survey-banner" . }}
 	{{ partial "header" . }}
 	{{ block "main" . }}{{ end }}
 	{{ partial "footer" . }}

--- a/layouts/partials/survey-banner.html
+++ b/layouts/partials/survey-banner.html
@@ -1,0 +1,9 @@
+<section id="survey-banner" class="survey-container">
+  <a 
+    class="survey-content"
+    href="https://docs.google.com/forms/d/e/1FAIpQLSd1TLjRzH1LNO1RXJA_Kgi6uHFoJhq9sM5OgOqyIldodgeSNg/viewform" 
+    target="_blank"
+  >
+    ❄️ Happy Holidays from Kubewarden ❄️ Click here to fill out our survey ❄️
+  </a>
+</section>


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #204 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This adds the Users Survey as a banner to the main page.

### Potential improvement

Should we use a few icons to bring attention to the text similar to [Kyverno's github stars banner?](https://kyverno.io/)
<!-- Please describe, if any, potential improvement that you are envisioning -->
