### PR TITLE
GH action: stop using a forked action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,7 @@ jobs:
         with:
           submodules: true
       - name: Publish Site
-        # We use a forked action due to
-        # https://github.blog/2022-04-12-git-security-vulnerability-announced/ (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765).
-        uses: kubewarden/hugo-gh-pages@fix-publishing
+        uses: chabad360/hugo-gh-pages@master
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           hugoVersion: extended_0.82.0


### PR DESCRIPTION
Go back to use the official release of https://github.com/chabad360/hugo-gh-pages instead of our fork.

Our fixes have been merged a long time ago. See https://github.com/chabad360/hugo-gh-pages/pull/21
