### PR TITLE
Install cert-manager via Helm in first steps

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -105,9 +105,10 @@ date: 2021-04-16T13:28:46+02:00
     <h2 class="text-center">Get Started</h2>
     <pre>
 <code>
+$ helm repo add jetstack https://charts.jetstack.io
+$ helm install --wait --namespace cert-manager --create-namespace --set installCRDs=true cert-manager jetstack/cert-manager
+
 $ helm repo add kubewarden https://charts.kubewarden.io
-$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
-$ kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 $ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds
 $ helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
 $ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults


### PR DESCRIPTION
## Description

Upstream docs don't wait via `kubectl wait` anymore (see [here](https://cert-manager.io/docs/installation/kubectl/)), and we know that installing via Helm waits correctly. We are also testing the cert-manager installation via helm, too.





<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Already using Helm in E2E tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
