### PR TITLE
Use new CNCF Google Analytics 4 (GA4) site ID

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ enableRobotsTXT = true
 pygmentsCodeFences = true
 pygmentsCodeFencesGuessSyntax = true
 enableGitInfo = true
-googleAnalytics = 'UA-56382716-13'
+googleAnalytics = 'G-PSW07XK7TM'
 
 [blackfriday]
 fractions = false


### PR DESCRIPTION
- Contributes to #144 by updating the GA site ID for the `www` subdomain.
  - @jvanz, as I mentioned in https://cncfservicedesk.atlassian.net/browse/CNCFSD-2256, your team will need to make the corresponding updates for the other subdomains, such as `docs`, `charts`, and any other.
  - Related issue: #224
  - Because of #224, I can already confirm that the new GA4 ID is receiving data 🤷🏼‍♂️ 😄 
- Uses the new GA4 site ID `G-PSW07XK7TM`

/cc @nate-double-u
