### PR TITLE
fix: disable Google analytics when building on Netlify.

### DIFF
--- a/config-netlify.toml
+++ b/config-netlify.toml
@@ -1,0 +1,5 @@
+# This configuration file exists to disable Google Analytics tracking in the
+# Netlify preview environment. It is not used in production.
+[privacy]
+  [privacy.googleAnalytics]
+    disable = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+# Configuration file to customize the build process of the website when
+# previewing it on Netlify.
+[build]
+publish = "public"
+command = "hugo --config config.toml,config-netlify.toml"
+
+


### PR DESCRIPTION
## Description

Customizes the Netlify build used to preview the website disabling the Google analytics. Therefore, we do not pollute our dashboard with development data.

Fix #224 