### PR TITLE
Remove graphic, rearrange page sequence, add link for latest version.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ params = ["categories", "tags"]
   github = "https://github.com/kubewarden"
 
 [outputs]
-home = ["HTML", "RSS", "Algolia"]
+home = ["HTML", "RSS"]
 
 [privacy]
   [privacy.googleAnalytics]

--- a/content/_index.html
+++ b/content/_index.html
@@ -7,7 +7,7 @@ date: 2021-04-16T13:28:46+02:00
     <div class="wrap grid-one">
       <div>
         <h1 style="color: white;">Kubernetes Dynamic Admission at your fingertips</h1>
-        <h4 style="color: white;">Flexible, secure and portable thanks to WebAssembly</h4>
+				<h4 style="color: white;">Flexible, secure and portable thanks to WebAssembly. Get started with the latest version - <a href="#get-started">1.12</a></h4>
       </div>
     </div>
   </div>
@@ -71,7 +71,6 @@ date: 2021-04-16T13:28:46+02:00
 
 <section class="wrap">
   <h2>How it Works</h2>
-  <img src="../images/how-it-works-kubewarden.svg" alt="{{ .Site.Title }}" style="padding: 3em; background: #eeeeee; border-radius: 25px;">
 
   <p class="text-left font-weight-light">Kubewarden integrates with Kubernetes by providing a set of Custom Resources. These Custom
   Resources simplify the process of enforcing policies on your cluster.</p>
@@ -83,6 +82,25 @@ date: 2021-04-16T13:28:46+02:00
   </p>
 </section>
 <hr />
+
+<section class="get-started">
+  <div class="white">
+    <h2 class="text-center" id="get-started">Get Started</h2>
+    <pre>
+<code>
+$ helm repo add jetstack https://charts.jetstack.io
+$ helm install --wait -n cert-manager --create-namespace --set installCRDs=true cert-manager jetstack/cert-manager
+
+$ helm repo add kubewarden https://charts.kubewarden.io
+$ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds
+$ helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
+$ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
+
+$ # ... and continue reading <a href="https://docs.kubewarden.io/quick-start" style="color: white;">the quick start</a> documentation
+</code>
+      </pre>
+  </div>
+</section>
 
 <section class="wrap">
   <h2 id="get-in-touch">Get in Touch</h2>
@@ -98,29 +116,6 @@ date: 2021-04-16T13:28:46+02:00
 
   <h3>Upcoming events</h3>
   <iframe src="https://teamup.com/ks2bj74dvw132mhjtj?view=a&tz=UTC&showLogo=0&showSearch=0&showProfileAndInfo=0&showSidepanel=1&disableSidepanel=1&showTitle=0&showViewSelector=0&showMenu=0&showAgendaHeader=0&showAgendaDetails=0&showYearViewHeader=0" style="width: 100%; height: 400px; border: 1px solid #cccccc" loading="lazy" frameborder="0"></iframe>
-</section>
-
-<section class="get-started">
-  <div class="white">
-    <h2 class="text-center">Get Started</h2>
-    <pre>
-<code>
-$ helm repo add jetstack https://charts.jetstack.io
-$ helm install --wait -n cert-manager --create-namespace --set installCRDs=true cert-manager jetstack/cert-manager
-
-$ helm repo add kubewarden https://charts.kubewarden.io
-$ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds
-$ helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
-$ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
-
-$ # ... and continue reading <a href="https://docs.kubewarden.io/quick-start" style="color: white;">the quick start</a> documentation
-</code>
-      </pre>
-  </div>
-  <div class="bg-primary">
-    <div class="wrap">
-    </div>
-  </div>
 </section>
 
 <section class="bg-light text-center cncf">


### PR DESCRIPTION
## Description

Fix #218

I have removed the architecture graphic, as discussed in the daily on 2024-05-30.

I have added 'Get started with the latest version - 1.12' in the banner. This links to the 'Get started' section on the same page.

Does that look ok?

I have some questions. 

Do those 'get started instructions' install the latest/current version?

The '1.12' should be updated automatically. I don't know how to do it but `updatecli` may be useful. Does anybody know how to set this up? It appears to be running in the docs repo, but not here. I'll need to get familiar.

So, in Draft, given the questions.

Lastly. Algolia is not being used for this site at the moment, and the change in `config.toml` allowed me to run `hugo server` locally for testing. Otherwise, the build breaks on `layouts/_default/list.algolia.json`. Any better ideas?
