### PR TITLE
updatecli for updating the version number on kubewarden.io front page

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install Updatecli Binary
         uses: updatecli/updatecli-action@eb158f6fd9e425b940a6750d6318f98e050ac390 # v2.6.1

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -5,9 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '15 */2 * * *'
-  repository_dispatch:
-    types: [kubewarden-controller-release]
+    - cron: '15 3 * * *'
 
 permissions:
   contents: write
@@ -20,19 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-      #   cache: yarn
-
-      #  https://github.com/actions/setup-node/issues/490
-      - name: Repair NPM  # Update to latest npm and yarn
-        run: "npm install -g npm yarn"
-
-      - name: Install Dependencies
-        run: "yarn install --frozen-lockfile"
 
       - name: Install Updatecli Binary
         uses: updatecli/updatecli-action@v2

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -17,10 +17,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
 
       - name: Install Updatecli Binary
-        uses: updatecli/updatecli-action@v2
+        uses: updatecli/updatecli-action@eb158f6fd9e425b940a6750d6318f98e050ac390 # v2.6.1
 
       - name: Run Updatecli in enforce mode
         run: "updatecli compose apply"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,44 @@
+---
+name: "Updatecli: Dependency Management"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '15 */2 * * *'
+  repository_dispatch:
+    types: [kubewarden-controller-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      #   cache: yarn
+
+      #  https://github.com/actions/setup-node/issues/490
+      - name: Repair NPM  # Update to latest npm and yarn
+        run: "npm install -g npm yarn"
+
+      - name: Install Dependencies
+        run: "yarn install --frozen-lockfile"
+
+      - name: Install Updatecli Binary
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli in enforce mode
+        run: "updatecli compose apply"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/content/_index.html
+++ b/content/_index.html
@@ -7,7 +7,7 @@ date: 2021-04-16T13:28:46+02:00
     <div class="wrap grid-one">
       <div>
         <h1 style="color: white;">Kubernetes Dynamic Admission at your fingertips</h1>
-				<h4 style="color: white;">Flexible, secure and portable thanks to WebAssembly. Get started with the latest version - <a href="#get-started">1.12</a></h4>
+				<h4 style="color: white;">Flexible, secure and portable thanks to WebAssembly. Get started with the latest version - <a href="#get-started">1.13</a></h4>
       </div>
     </div>
   </div>

--- a/content/_index.html
+++ b/content/_index.html
@@ -7,7 +7,7 @@ date: 2021-04-16T13:28:46+02:00
     <div class="wrap grid-one">
       <div>
         <h1 style="color: white;">Kubernetes Dynamic Admission at your fingertips</h1>
-				<h4 style="color: white;">Flexible, secure and portable thanks to WebAssembly. Get started with the latest version - <a href="#get-started">1.13</a></h4>
+				<h4 style="color: white;">Flexible, secure and portable thanks to WebAssembly. Get started with the latest version - <a href="#get-started">1.12</a></h4>
       </div>
     </div>
   </div>

--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -1,0 +1,11 @@
+# Following policies are designed to work on GitHub action and therefor needs the two following 
+# environment variables
+# * GITHUB_TOKEN
+# * GITHUB_ACTOR
+#
+# Once available you can run the command `updatecli compose diff --experimental` to see what would change.
+
+policies:
+  - name: Kubewarden specific policies
+    config: 
+      - updatecli/updatecli.d/

--- a/updatecli/updatecli.d/updcli-kw-ver.yml
+++ b/updatecli/updatecli.d/updcli-kw-ver.yml
@@ -1,0 +1,59 @@
+name: 'docs: update Kubewarden version on frontpage of kubewarden.io'
+pipelineid: kubewarden-controller/latest
+
+actions:
+  default:
+    title: 'updatecli: docs: update Kubewarden version to {{ source "kwc-version" }} on front page of kubewarden.io'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      labels:
+        - chore
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "UPDATECLI_GITHUB_OWNER"
+      email: kubewarden@suse.de
+      owner: "UPDATECLI_GITHUB_OWNER"
+      author: "Kubewarden bot"
+      repository: kubewarden.io
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      branch: main
+      commitmessage:
+        type: "chore"
+        title: 'docs: update Kubewarden version to {{ source "kwc-version" }} on kubewarden.io front page'
+
+sources:
+  kwc-version:
+    name: Get the latest Kubewarden controller version
+    kind: githubrelease
+    spec:
+      owner: kubewarden
+      repository: kubewarden-controller
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+        pattern: ">0.1"
+    transformers:
+      - trimprefix: "v"
+      - trimsuffix: ".0"
+
+
+targets:
+  kwc-update-vno:
+    name: 'docs: update Kubewarden with version {{ source "kwc-version" }}'
+    kind: file
+    sourceid: kwc-version
+    spec:
+      files:
+        - content/_index.html
+      matchpattern: '<a href="#get-started">(.*)</a>'
+      replacepattern: '<a href="#get-started">{{ source "kwc-version" }}</a>'
+    scmid: default
+


### PR DESCRIPTION
updatecli for updating the version number on kubewarden.io front page

Adds updatecli config for updating the version number on the front page of kubewarden.io. Also resets to 1.12 as a test. It should be auto PRed by the cron schedule within two hours.

Will close #229 on merge.