### PR TITLE
Update cert manager to support v1.15

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -89,7 +89,7 @@ date: 2021-04-16T13:28:46+02:00
     <pre>
 <code>
 $ helm repo add jetstack https://charts.jetstack.io
-$ helm install --wait -n cert-manager --create-namespace --set installCRDs=true cert-manager jetstack/cert-manager
+$ helm install --wait -n cert-manager --create-namespace --set crds.enabled=true cert-manager jetstack/cert-manager
 
 $ helm repo add kubewarden https://charts.kubewarden.io
 $ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds


### PR DESCRIPTION
PR fixes installation warning:
```
⚠️  WARNING: `installCRDs` is deprecated, use `crds.enabled` instead.
```
Related to https://github.com/kubewarden/docs/pull/427