### PR TITLE
fix: remove logos from footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,29 +1,12 @@
 <footer>
-	<p>
-		&copy; {{ now.Year }} Kubewarden Project Authors. All rights reserved.
-		The Linux Foundation has registered trademarks and uses trademarks.
-		For a list of trademarks of The Linux Foundation, please see our Trademark Usage page:
-		<a href="https://www.linuxfoundation.org/trademark-usage">
-			https://www.linuxfoundation.org/trademark-usage
-		</a>
-	</p>
-	<div class="project-icons">
-		<a href="https://k3s.io" target="blank">
-			<img src="/images/icon-k3s.svg" height="20">
-		</a>
-		<a href="https://harvesterhci.io" target="blank">
-			<img src="/images/icon-harvester.svg" height="20">
-		</a>
-		<a href="https://rancherdesktop.io" target="blank">
-			<img src="/images/icon-rancher-desktop.svg" height="20">
-		</a>
-		<a href="https://epinio.io" target="blank">
-			<img src="/images/icon-epinio.svg" height="20">
-		</a>
-		<a href="https://hypper.io" target="blank">
-			<img src="/images/icon-hypper.svg" height="20">
-		</a>
-	</div>
+  <p>
+    &copy; {{ now.Year }} Kubewarden Project Authors. All rights reserved.
+    The Linux Foundation has registered trademarks and uses trademarks.
+    For a list of trademarks of The Linux Foundation, please see our Trademark Usage page:
+    <a href="https://www.linuxfoundation.org/trademark-usage">
+      https://www.linuxfoundation.org/trademark-usage
+    </a>
+  </p>
 </footer>
 
 {{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
Remove logos of other projects (some of them CNCF, others Rancher related) from the footer of the page.

This is something CNCF projects should not be doing.
