### PR TITLE
Remove cert-manager from index page

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -88,15 +88,13 @@ date: 2021-04-16T13:28:46+02:00
     <h2 class="text-center" id="get-started">Get Started</h2>
     <pre>
 <code>
-$ helm repo add jetstack https://charts.jetstack.io
-$ helm install --wait -n cert-manager --create-namespace --set crds.enabled=true cert-manager jetstack/cert-manager
+helm repo add kubewarden https://charts.kubewarden.io
 
-$ helm repo add kubewarden https://charts.kubewarden.io
-$ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds
-$ helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
-$ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
+helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds
+helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
+helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
 
-$ # ... and continue reading <a href="https://docs.kubewarden.io/quick-start" style="color: white;">the quick start</a> documentation
+# ... and continue reading <a href="https://docs.kubewarden.io/quick-start" style="color: white;">the quick start</a> documentation
 </code>
       </pre>
   </div>


### PR DESCRIPTION
## Description

- removed `$` since it breaks multiline copy & paste
- removed cert-manager mentions
