### PR TITLE
fix: do not define baseURL in CI.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
           set -e
 
           hugo --gc --minify --cleanDestinationDir \
-            --baseURL "${{ steps.pages.outputs.base_url }}/" \
             -d ${{ runner.temp }}/gh-pages/
       - name: Upload gh-pages artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3.0.1


### PR DESCRIPTION
## Description

Remove the hugo cli flag used in the CI to define the baseURL and uses the value defined in the configuration file.
