### PR TITLE
fix(cd): Add temporal workaround for apt mirrors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Temporal workaround for innacessible mirrors
+        run: |
+          sudo sed -i 's|mirror+file:/etc/apt/apt-mirrors.txt|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo apt-get update
       - name: Install hugo
         run: |
           sudo apt install hugo


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Set a standard mirror instead of the ones already defined in `/etc/apt/apt-mirrors.txt`.

This allows us to publish for now.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested on my fork:  https://github.com/viccuad/kubewarden.io/actions/runs/15880207778

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
