### PR TITLE
fix: netlify build in the latest build image

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,5 @@
 publish = "public"
 command = "hugo --config config.toml,config-netlify.toml"
 
-
+[build.environment]
+HUGO_VERSION = "0.133.0"


### PR DESCRIPTION
# Description

Updates the Netlify configuration file to allow build the website in the latest version of the Netlify build image.


Fix #392 