### PR TITLE
chore(ci): define commit sha for actions/checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt install hugo
           hugo version
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - name: Setup Pages


### PR DESCRIPTION
## Description

Updates the publish.yml file setting the commit sha to pin the actions/checkout Github action version.


