### PR TITLE
Remove next from URL links referencing the docs.

### DIFF
--- a/content/blog/2023/11/raw-policies.md
+++ b/content/blog/2023/11/raw-policies.md
@@ -47,7 +47,7 @@ This one is accepted but the request is mutated:
 
 ## Conclusion
 
-If you want to learn more about Raw policies, please check out the [how-to](https://docs.kubewarden.io/next/howtos/raw-policies).
+If you want to learn more about Raw policies, please check out the [how-to](https://docs.kubewarden.io/howtos/raw-policies).
 
 We are excited to see how the community will use this new feature.
 What are you going to build with it? We are curious to know!

--- a/content/blog/2024/03/kubewarden-1-11-release.md
+++ b/content/blog/2024/03/kubewarden-1-11-release.md
@@ -61,7 +61,7 @@ The Kubewarden SDKs have been updated to expose this new functionality. We will 
 
 ## Context aware policies optimization
 
-As part of our host capabilities, Kubewarden provides a way to query the Kubernetes API server. This is used to create [context aware policies](https://docs.kubewarden.io/next/reference/spec/context-aware-policies).
+As part of our host capabilities, Kubewarden provides a way to query the Kubernetes API server. This is used to create [context aware policies](https://docs.kubewarden.io/reference/spec/context-aware-policies).
 These are policies that use information about the state of Kubernetes cluster to make validating/mutating decisions.
 
 Starting from the 1.11 release, Kubewarden uses a different way to fetch information from the Kubernetes API server and keep this data up to date. That brings two major improvements.

--- a/content/blog/2024/03/oci-manifest-capability.md
+++ b/content/blog/2024/03/oci-manifest-capability.md
@@ -30,7 +30,7 @@ image has the [SPDX license
 annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys).
 Consider this Rust validation code:
 
-```rust 
+```rust
 fn has_license_specified(image: &str) -> Result<bool> {
     let manifest = get_manifest(image)?;
     match manifest {
@@ -85,7 +85,7 @@ a cluster.
 ## Conclusion
 
 To learn more about this and other host capabilities, refer to the [official
-documentation](https://docs.kubewarden.io/next/writing-policies/spec/host-capabilities/container-registry#oci-manifest).
+documentation](https://docs.kubewarden.io/writing-policies/spec/host-capabilities/container-registry#oci-manifest).
 
 We look forward to seeing how the community utilizes this new feature to
 develop innovative solutions. Share your ideas with us on our [Slack

--- a/content/blog/2024/04/kubewarden-1-12-release.md
+++ b/content/blog/2024/04/kubewarden-1-12-release.md
@@ -15,7 +15,7 @@ production.
 The previous [1.11
 release](https://www.kubewarden.io/blog/2024/03/kubewarden-1-11-release/)
 featured lots of optimizations for
-[context aware policies](https://docs.kubewarden.io/next/reference/spec/context-aware-policies).
+[context aware policies](https://docs.kubewarden.io/reference/spec/context-aware-policies).
 
 The 1.12 release provides a further optimization for Gatekeeper policies that
 access Kubernetes resources. This optimization provides an extra 55%
@@ -32,7 +32,7 @@ on big clusters where hundreds of Pod objects are defined.
 
 Due to community requests for increasing deployment availability of
 Kubewarden, from 1.12 each [PolicyServer
-spec](https://docs.kubewarden.io/next/reference/CRDs#policyserverspec) has
+spec](https://docs.kubewarden.io/reference/CRDs#policyserverspec) has
 additional fields to configure policy-server Deployment behavior in clusters:
 
 - `spec.minAvailable` or `spec.maxUnavailable`: Configure the number of

--- a/content/blog/2024/10/kubewarden-1-17-release.md
+++ b/content/blog/2024/10/kubewarden-1-17-release.md
@@ -106,7 +106,7 @@ As usual, the CRDs are documented in our
 [reference](https://docs.kubewarden.io/reference/CRDs#resource-types) docs. And
 you can read their
 [explanation](https://docs.kubewarden.io/explanations/policy-groups) and an
-in-depth [how-to](https://docs.kubewarden.io/next/howtos/policy-groups) on the
+in-depth [how-to](https://docs.kubewarden.io/howtos/policy-groups) on the
 docs for these resources.
 
 Stay tuned for a new deep dive blog post!

--- a/content/blog/2024/10/policy-groups.md
+++ b/content/blog/2024/10/policy-groups.md
@@ -249,7 +249,7 @@ Error from server: error when creating "second-service.yml": admission webhook "
 ### Audit scanner
 
 Another way of obtaining details on the state of the cluster is the [Audit
-Scanner](https://docs.kubewarden.io/next/explanations/audit-scanner).
+Scanner](https://docs.kubewarden.io/explanations/audit-scanner).
 Policy Groups are fully supported in the Kubewarden stack, and their results
 get published to Policy Reports.
 
@@ -266,7 +266,7 @@ particularly with paired with CEL via the [cel-policy](https://artifacthub.io/pa
 Have a look at their CRD
 [reference](https://docs.kubewarden.io/reference/CRDs#resource-types) docs,
 their [explanation](https://docs.kubewarden.io/explanations/policy-groups) and
-[how-to](https://docs.kubewarden.io/next/howtos/policy-groups) on our docs.
+[how-to](https://docs.kubewarden.io/howtos/policy-groups) on our docs.
 
 ## Getting in touch
 

--- a/content/blog/2025/01/kubewarden-1-21-release.md
+++ b/content/blog/2025/01/kubewarden-1-21-release.md
@@ -145,12 +145,12 @@ These pages are automatically synchronized with the actual implementation, they 
 [Policy Server](https://docs.kubewarden.io/reference/policy-server-cli).
 
 These documentation pages can also be generated locally using the new docs subcommands. For example, to generate the kwctl documentation you can
-invoke the following command: `kwctl docs --output docs.md`. 
+invoke the following command: `kwctl docs --output docs.md`.
 
 ### New pages
 
-As part of improvements suggested by a CNCF documentation review a [personas](https://docs.kubewarden.io/next/personas)
-and a [document organization](https://docs.kubewarden.io/next/organization) page have been added.
+As part of improvements suggested by a CNCF documentation review a [personas](https://docs.kubewarden.io/personas)
+and a [document organization](https://docs.kubewarden.io/organization) page have been added.
 Also, the introduction section has been reworded to highlight Kubewarden’s benefits more effectively.
 
 ## New social media presence
@@ -164,4 +164,3 @@ We’re happy to inform you that we have left X and you can now follow the Kubew
 As always, we welcome your feedback and contributions. Feel free to reach out
 to us on [Slack](https://kubernetes.slack.com/?redir=%2Fmessages%2Fkubewarden)
 and [GitHub discussions](https://github.com/orgs/kubewarden/discussions).
-

--- a/content/blog/2025/08/kubewarden-1.28-release.md
+++ b/content/blog/2025/08/kubewarden-1.28-release.md
@@ -42,7 +42,7 @@ spec:
 ```
 
 With this manifest and the [`hauler`
-cli](https://docs.hauler.dev/docs/next/introduction/install) tool, you can
+cli](https://docs.hauler.dev/docs/introduction/install) tool, you can
 create an archive file with all the needed artifacts (Helm charts, container
 images, policies). This also verifies the artifacts via cosign, so you can
 confidently jump past the air gap to install or regularly update your
@@ -59,7 +59,7 @@ Kubewarden stack:
             oci://my-secure-airgap-registry/hauler/kubewarden-crds
 ```
 
-You can find a more complete [how-to example](https://docs.kubewarden.io/next/howtos/airgap/hauler)
+You can find a more complete [how-to example](https://docs.kubewarden.io/howtos/airgap/hauler)
 in our docs.
 
 For this new feature, we automated the creation on this Hauler manifest with

--- a/content/blog/2025/10/kubewarden-1.30-release.md
+++ b/content/blog/2025/10/kubewarden-1.30-release.md
@@ -125,7 +125,7 @@ We have expanded support on performing migrations from VAPs into Kubewarden's
 CEL policy with `kwctl scaffold vap`, which now supports params.
 
 The tutorial on [reusing VAPs into our CEL
-policy](https://docs.kubewarden.io/next/tutorials/writing-policies/CEL/reusing-vap)
+policy](https://docs.kubewarden.io/tutorials/writing-policies/CEL/reusing-vap)
 has also been refreshed, have a look!
 
 ## PriorityClass policy gains mutation & denylist

--- a/content/blog/2026/02/kubewarden-1.32-release.md
+++ b/content/blog/2026/02/kubewarden-1.32-release.md
@@ -100,7 +100,7 @@ The GitHub releases under [kubewarden/helm-charts](https://github.com/kubewarden
 no longer ship a `<charts>_images.xt`, and each of the Helm charts keeps
 including their own `imagelist.txt` and `policylist.txt` inside the charts to
 aid in air-gap installation. See our updated [air-gap
-docs](https://docs.kubewarden.io/next/howtos/airgap/install) (we recommend
+docs](https://docs.kubewarden.io/howtos/airgap/install) (we recommend
 using [Hauler](https://docs.hauler.dev/docs/intro)).
 
 ### Changes to Cosign signature metadata
@@ -140,7 +140,7 @@ sync: if the `policy-server` container image gets a patch release, so will be
 the `kubewarden-controller` image and our `kwctl` utility. As usual, we have
 documented this in our [RFC](https://github.com/kubewarden/rfc/pull/53) repo,
 as well as updated the
-[docs](https://docs.kubewarden.io/next/reference/upgrade-path#stack-version-compatibility-among-components).
+[docs](https://docs.kubewarden.io/reference/upgrade-path#stack-version-compatibility-among-components).
 
 ## Ongoing cleanup touches
 

--- a/content/blog/2026/03/adm-controller-1.33-release.md
+++ b/content/blog/2026/03/adm-controller-1.33-release.md
@@ -130,7 +130,7 @@ the whole of it.
 
 We have enhanced our Policy SDKs to expose this new field mask feature. Policy
 SDK authors can also find this new `field_masks` input field in the Kubernetes
-[host-calls](https://docs.kubewarden.io/next/reference/spec/host-capabilities/kubernetes#operation---list_resources_all).
+[host-calls](https://docs.kubewarden.io/reference/spec/host-capabilities/kubernetes#operation---list_resources_all).
 
 In addition, we have enhanced our
 [cel-policy](https://artifacthub.io/packages/kubewarden/kubewarden-policy-library/cel-policy),


### PR DESCRIPTION
So that links within old blog posts to next docs new docs can work with the new Antora docs.