### PR TITLE
allow blog post scheduling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,13 @@
+---
 name: Publish Site
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+  schedule:
+    # shortly after midnight UTC.
+    - cron: '12 0 * * *'
 permissions:
   contents: read
   pages: write

--- a/config-netlify.toml
+++ b/config-netlify.toml
@@ -1,3 +1,6 @@
+# publish everything on netlify, including stuff that's suposed to go out in the future
+buildFuture = true
+
 # This configuration file exists to disable Google Analytics tracking in the
 # Netlify preview environment. It is not used in production.
 [privacy]

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 baseURL = ""
 languageCode = "en-us"
+timeZone = "UTC"
 title = "Kubewarden"
 theme = "projects-theme"
 pluralizeListTitles = false


### PR DESCRIPTION
## Description

- build page on a schedule
- build on netlify with future postings (to have a PR preview)

## Test

- check on netlify in this PR

## Additional Information

### Tradeoff

- builds every day


## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
