### PR TITLE
feat: blogpost adm-controller 1.38, mem growth section with 3 graphs

### DIFF
--- a/content/blog/2026/09/admission-controller-1.38-release.md
+++ b/content/blog/2026/09/admission-controller-1.38-release.md
@@ -1,0 +1,75 @@
+---
+title: "Admission controller 1.38 Release"
+authors:
+  - Víctor Cuadrado Juan
+date: 2026-09-17
+---
+
+TODO
+
+## Fixing an unbounded memory growth with context-aware policies
+
+A user reported to us that the policy-server memory grew steadily and never
+came down when using context-aware policies. In their setup, the memory
+of the policy-server grew to 22GB (!). This is incredible, and needed around
+28 million of unique `can_i` host-capability calls from the policies to reach
+that memory consumption. Of course, in their setup the policy-server got
+OOM-killed.
+
+The cause turned out to be the caches for context-aware host calls such as
+`can_i` and `get_resource`. The caches used the `cached` crate with a TTL and
+no size bound. In this cache implementation from the `cached` library, the
+cache removes an expired entry only when the same key is queried again.
+Context-aware policies produce a stream of distinct keys (unique pod names,
+service accounts, subjects), so if those entries are unique, the cache keys
+accumulated forever. The TTL marked the entries as not fresh, but nothing
+removed the entries from memory.
+
+After pondering several options, we decided to move to a different cache
+implementation, with the crate [moka]. `moka` removes expired
+entries during routine cache operations, so memory follows the current
+request rate instead of the total number of unique keys ever seen. The cache
+behavior does not change: same TTL windows, same keys, and concurrent misses
+for the same key still make one backend call.
+
+We verified the fix end to end on a cluster. After 60,000 unique keys, the
+`cached` heap held +47.2 MB and released zero bytes during idle. The moka
+heap peaked at +4.7 MB and decayed to 3.15 MB:
+
+{{< figure class="center" src="/images/memory-growth.svg" width="100%" alt="Heap growth: cached grows and freezes, moka peaks and decays">}}
+
+This is already great, as we are getting our memory back. Bad days to waste
+memory nowadays!
+
+But not only that. We knew that the `cached` crate held a global lock across
+the backend call, and `moka` is async. With `cached`, the concurrent misses for
+different keys gave us a maximum roof of requests-per-second (rps). In my laptop,
+this meant about 480 rps. In contrast, `moka` runs in parallel, which
+tremendously increases the throughput:
+
+{{< figure class="center" src="/images/miss-throughput.svg" width="100%" alt="Unique-key flood throughput">}}
+
+The lock also made cache hits queue behind in-flight misses. In a 90% hit /
+10% miss workload at concurrency 64, the median dropped from 12.8 ms to
+42 µs in my laptop:
+
+{{< figure class="center" src="/images/mixed-p50.svg" width="100%" alt="Mixed workload median latency">}}
+
+At normal request rates the change is latency-neutral: 12 e2e runs at
+200 rps and probes at 1000 rps showed parity between the two
+implementations. 
+
+Huge thanks to [@Pinguladora](https://github.com/Pinguladora) for the initial
+detailed report with reproducer.
+
+[issue #1950]: https://github.com/kubewarden/adm-controller/issues/1950
+[PR #1952]: https://github.com/kubewarden/adm-controller/pull/1952
+[moka]: https://github.com/moka-rs/moka
+
+
+## Getting in touch
+
+Join the conversation on
+[Slack](https://kubernetes.slack.com/?redir=%2Fmessages%2Fkubewarden) or
+[GitHub discussions](https://github.com/orgs/kubewarden/discussions) and let us
+know how you're finding Kubewarden 1.38!

--- a/content/blog/2026/09/admission-controller-1.38-release.md
+++ b/content/blog/2026/09/admission-controller-1.38-release.md
@@ -26,17 +26,17 @@ accumulated forever. The TTL marked the entries as not fresh, but nothing
 removed the entries from memory.
 
 After pondering several options, we decided to move to a different cache
-implementation, with the crate [moka]. `moka` removes expired
+implementation, with the crate [moka](https://github.com/moka-rs/moka). `moka` removes expired
 entries during routine cache operations, so memory follows the current
 request rate instead of the total number of unique keys ever seen. The cache
 behavior does not change: same TTL windows, same keys, and concurrent misses
 for the same key still make one backend call.
 
 We verified the fix end to end on a cluster. After 60,000 unique keys, the
-`cached` heap held +47.2 MB and released zero bytes during idle. The moka
+`cached` heap held +47.2 MB and released zero bytes during idle. The `moka`
 heap peaked at +4.7 MB and decayed to 3.15 MB:
 
-{{< figure class="center" src="/images/memory-growth.svg" width="100%" alt="Heap growth: cached grows and freezes, moka peaks and decays">}}
+{{< figure class="center" src="/images/1.38-memory-growth.svg" width="100%" alt="Heap growth: cached grows and freezes, moka peaks and decays">}}
 
 This is already great, as we are getting our memory back. Bad days to waste
 memory nowadays!
@@ -47,13 +47,13 @@ different keys gave us a maximum roof of requests-per-second (rps). In my laptop
 this meant about 480 rps. In contrast, `moka` runs in parallel, which
 tremendously increases the throughput:
 
-{{< figure class="center" src="/images/miss-throughput.svg" width="100%" alt="Unique-key flood throughput">}}
+{{< figure class="center" src="/images/1.38-miss-throughput.svg" width="100%" alt="Unique-key flood throughput">}}
 
 The lock also made cache hits queue behind in-flight misses. In a 90% hit /
 10% miss workload at concurrency 64, the median dropped from 12.8 ms to
 42 µs in my laptop:
 
-{{< figure class="center" src="/images/mixed-p50.svg" width="100%" alt="Mixed workload median latency">}}
+{{< figure class="center" src="/images/1.38-mixed-p50.svg" width="100%" alt="Mixed workload median latency">}}
 
 At normal request rates the change is latency-neutral: 12 e2e runs at
 200 rps and probes at 1000 rps showed parity between the two

--- a/static/images/1.38-memory-growth.svg
+++ b/static/images/1.38-memory-growth.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 440" role="img" aria-labelledby="t d" font-family="ui-sans-serif, system-ui, sans-serif">
+  <title id="t">Heap in-use memory: cached versus moka</title>
+  <desc id="d">Line chart. After 60,000 unique cache keys, the cached crate holds 47.2 MB and does not release it during idle. moka peaks at 4.7 MB and decays to 3.15 MB.</desc>
+  <style>
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .grid { stroke: #e2e8f0; stroke-width: 1; }
+    .lbl  { fill: #475569; font-size: 13px; }
+    .tick { fill: #64748b; font-size: 12px; }
+    .cached { stroke: #dc2626; }
+    .moka   { stroke: #16a34a; }
+  </style>
+  <rect width="760" height="440" fill="#ffffff"/>
+  <text x="380" y="28" text-anchor="middle" font-size="17" font-weight="600" fill="#0f172a">Heap in-use after unique-key traffic (60k keys, then idle)</text>
+
+  <!-- plot area: x 80..690, y 60..360; y scale 0..50 MB -->
+  <g class="grid">
+    <line x1="80" y1="300" x2="690" y2="300"/>
+    <line x1="80" y1="240" x2="690" y2="240"/>
+    <line x1="80" y1="180" x2="690" y2="180"/>
+    <line x1="80" y1="120" x2="690" y2="120"/>
+    <line x1="80" y1="60"  x2="690" y2="60"/>
+  </g>
+  <g class="tick" text-anchor="end">
+    <text x="72" y="364">0</text>
+    <text x="72" y="304">10</text>
+    <text x="72" y="244">20</text>
+    <text x="72" y="184">30</text>
+    <text x="72" y="124">40</text>
+    <text x="72" y="64">50</text>
+  </g>
+  <text class="lbl" x="24" y="210" transform="rotate(-90 24 210)" text-anchor="middle">heap in-use (MB)</text>
+
+  <line class="axis" x1="80" y1="360" x2="690" y2="360"/>
+  <line class="axis" x1="80" y1="60"  x2="80"  y2="360"/>
+
+  <!-- x scale: 0..60k keys maps 80..560; idle zone 560..690 -->
+  <g class="tick" text-anchor="middle">
+    <text x="80"  y="380">0</text>
+    <text x="272" y="380">24k</text>
+    <text x="560" y="380">60k</text>
+    <text x="625" y="380">idle 60 s</text>
+  </g>
+  <text class="lbl" x="385" y="404" text-anchor="middle">unique cache keys processed, then idle period</text>
+  <line class="grid" x1="560" y1="60" x2="560" y2="360" stroke-dasharray="4 4"/>
+
+  <!-- cached: 0 -> 12.6MB @24k -> 47.2MB @60k, frozen in idle. y = 360 - MB*6 -->
+  <polyline class="cached" fill="none" stroke-width="3"
+    points="80,360 272,284.4 560,76.8 690,76.8"/>
+  <circle cx="272" cy="284.4" r="4" fill="#dc2626"/>
+  <circle cx="560" cy="76.8"  r="4" fill="#dc2626"/>
+  <text x="300" y="278" font-size="12" fill="#dc2626">+12.6 MB</text>
+  <text x="470" y="70" font-size="12" fill="#dc2626" font-weight="600">+47.2 MB</text>
+  <text x="600" y="98" font-size="12" fill="#dc2626">frozen, zero reclaim</text>
+
+  <!-- moka: 0 -> ~1MB @24k -> 4.7MB @60k -> 3.15MB after idle -->
+  <polyline class="moka" fill="none" stroke-width="3"
+    points="80,360 272,354 560,331.8 690,341.1"/>
+  <circle cx="560" cy="331.8" r="4" fill="#16a34a"/>
+  <circle cx="690" cy="341.1" r="4" fill="#16a34a"/>
+  <text x="500" y="322" font-size="12" fill="#16a34a" font-weight="600">+4.7 MB peak</text>
+  <text x="600" y="358" font-size="12" fill="#16a34a">decays to 3.15 MB</text>
+
+  <!-- legend -->
+  <g font-size="13">
+    <line x1="100" y1="46" x2="130" y2="46" class="cached" stroke-width="3"/>
+    <text x="136" y="50" fill="#334155">cached crate (before)</text>
+    <line x1="310" y1="46" x2="340" y2="46" class="moka" stroke-width="3"/>
+    <text x="346" y="50" fill="#334155">moka (after)</text>
+  </g>
+
+  <text x="380" y="428" text-anchor="middle" font-size="12" fill="#94a3b8">Source: jemalloc in-use bytes from /debug/pprof/heap, policy-server on minikube, k6 load with unique serviceAccountName per request</text>
+</svg>

--- a/static/images/1.38-miss-throughput.svg
+++ b/static/images/1.38-miss-throughput.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 440" role="img" aria-labelledby="t d" font-family="ui-sans-serif, system-ui, sans-serif">
+  <title id="t">Throughput on concurrent cache misses: cached versus moka</title>
+  <desc id="d">Bar chart with a linear scale. In a flood of 2,000 distinct keys with a 1 ms backend, cached stays near 480 requests per second at every concurrency. moka reaches 3,784 at concurrency 8 and 28,340 at concurrency 64.</desc>
+  <style>
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .grid { stroke: #e2e8f0; stroke-width: 1; }
+    .lbl  { fill: #475569; font-size: 13px; }
+    .tick { fill: #64748b; font-size: 12px; }
+    .val  { font-size: 13px; font-weight: 600; text-anchor: middle; }
+  </style>
+  <rect width="760" height="440" fill="#ffffff"/>
+  <text x="380" y="28" text-anchor="middle" font-size="17" font-weight="600" fill="#0f172a">Unique-key flood: 2,000 distinct keys, 1 ms backend</text>
+
+  <!-- plot area x 90..700, y 70..360. linear scale: 0 -> y360, 30000 -> y70. y = 360 - v*290/30000 -->
+  <g class="grid">
+    <line x1="90" y1="263.3" x2="700" y2="263.3"/>
+    <line x1="90" y1="166.7" x2="700" y2="166.7"/>
+    <line x1="90" y1="70"    x2="700" y2="70"/>
+  </g>
+  <g class="tick" text-anchor="end">
+    <text x="82" y="364">0</text>
+    <text x="82" y="267">10k</text>
+    <text x="82" y="171">20k</text>
+    <text x="82" y="74">30k</text>
+  </g>
+  <text class="lbl" x="26" y="215" transform="rotate(-90 26 215)" text-anchor="middle">requests per second</text>
+  <line class="axis" x1="90" y1="360" x2="700" y2="360"/>
+  <line class="axis" x1="90" y1="70"  x2="90"  y2="360"/>
+
+  <!-- groups at concurrency 1, 8, 64. group centers: 190, 395, 600. bar width 60, gap 10 -->
+  <!-- cached: 480 -> 355.4; 482 -> 355.3; 480 -> 355.4 -->
+  <!-- moka: 478 -> 355.4; 3784 -> 323.4; 28340 -> 86.1 -->
+  <g>
+    <!-- concurrency 1 -->
+    <rect x="125" y="355.4" width="60" height="4.6" fill="#dc2626" rx="1"/>
+    <rect x="195" y="355.4" width="60" height="4.6" fill="#16a34a" rx="1"/>
+    <text class="val" x="155" y="349" fill="#dc2626">480</text>
+    <text class="val" x="225" y="336" fill="#16a34a">478</text>
+    <!-- concurrency 8 -->
+    <rect x="330" y="355.3" width="60" height="4.7" fill="#dc2626" rx="1"/>
+    <rect x="400" y="323.4" width="60" height="36.6" fill="#16a34a" rx="1"/>
+    <text class="val" x="360" y="349" fill="#dc2626">482</text>
+    <text class="val" x="430" y="317" fill="#16a34a">3,784</text>
+    <!-- concurrency 64 -->
+    <rect x="535" y="355.4" width="60" height="4.6" fill="#dc2626" rx="1"/>
+    <rect x="605" y="86.1" width="60" height="273.9" fill="#16a34a" rx="1"/>
+    <text class="val" x="565" y="349" fill="#dc2626">480</text>
+    <text class="val" x="635" y="80" fill="#16a34a">28,340</text>
+  </g>
+
+  <!-- lock ceiling annotation -->
+  <line x1="90" y1="355.4" x2="700" y2="355.4" stroke="#dc2626" stroke-width="1" stroke-dasharray="6 4" opacity="0.6"/>
+  <line x1="292" y1="270" x2="292" y2="351" stroke="#dc2626" stroke-width="1" opacity="0.5"/>
+  <text x="292" y="262" text-anchor="middle" font-size="12" fill="#dc2626">cached global-lock ceiling (~1 / backend latency)</text>
+
+  <g class="tick" text-anchor="middle">
+    <text x="190" y="380">concurrency 1</text>
+    <text x="395" y="380">concurrency 8</text>
+    <text x="600" y="380">concurrency 64</text>
+  </g>
+  <text class="lbl" x="395" y="402" text-anchor="middle">Higher is better.</text>
+
+  <!-- legend -->
+  <g font-size="13">
+    <rect x="110" y="40" width="16" height="12" fill="#dc2626" rx="2"/>
+    <text x="132" y="50" fill="#334155">cached crate (before)</text>
+    <rect x="310" y="40" width="16" height="12" fill="#16a34a" rx="2"/>
+    <text x="332" y="50" fill="#334155">moka (after)</text>
+  </g>
+
+  <text x="380" y="424" text-anchor="middle" font-size="12" fill="#94a3b8">Source: microbenchmark of the can_i host-call path in policy-evaluator, mock API server with a fixed 1 ms delay</text>
+</svg>

--- a/static/images/1.38-mixed-p50.svg
+++ b/static/images/1.38-mixed-p50.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 440" role="img" aria-labelledby="t d" font-family="ui-sans-serif, system-ui, sans-serif">
+  <title id="t">Median latency in a mixed workload: cached versus moka</title>
+  <desc id="d">Bar chart with a linear scale. In a 90 percent hit and 10 percent miss workload, the cached crate median latency rises to 12.8 milliseconds at concurrency 64 because hits queue behind misses. moka stays at 42 microseconds.</desc>
+  <style>
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .grid { stroke: #e2e8f0; stroke-width: 1; }
+    .lbl  { fill: #475569; font-size: 13px; }
+    .tick { fill: #64748b; font-size: 12px; }
+    .val  { font-size: 13px; font-weight: 600; text-anchor: middle; }
+  </style>
+  <rect width="760" height="440" fill="#ffffff"/>
+  <text x="380" y="28" text-anchor="middle" font-size="17" font-weight="600" fill="#0f172a">Mixed workload (90% hits / 10% misses): median latency</text>
+
+  <!-- plot area x 90..700, y 70..360. linear scale: 0 ms -> y360, 13 ms -> y70. y = 360 - ms*22.3077 -->
+  <g class="grid">
+    <line x1="90" y1="270.8" x2="700" y2="270.8"/>
+    <line x1="90" y1="181.5" x2="700" y2="181.5"/>
+    <line x1="90" y1="92.3"  x2="700" y2="92.3"/>
+  </g>
+  <g class="tick" text-anchor="end">
+    <text x="82" y="364">0</text>
+    <text x="82" y="275">4 ms</text>
+    <text x="82" y="186">8 ms</text>
+    <text x="82" y="96">12 ms</text>
+  </g>
+  <text class="lbl" x="22" y="215" transform="rotate(-90 22 215)" text-anchor="middle">p50 latency</text>
+  <line class="axis" x1="90" y1="360" x2="700" y2="360"/>
+  <line class="axis" x1="90" y1="70"  x2="90"  y2="360"/>
+
+  <!-- values: cached 3 µs / 2.1 ms / 12.8 ms; moka 5 µs / 9 µs / 42 µs.
+       Microsecond bars round to less than 1 px; drawn at a 2 px minimum height. -->
+  <g>
+    <!-- concurrency 1 -->
+    <rect x="125" y="358" width="60" height="2" fill="#dc2626" rx="1"/>
+    <rect x="195" y="358" width="60" height="2" fill="#16a34a" rx="1"/>
+    <text class="val" x="155" y="352" fill="#dc2626">3 µs</text>
+    <text class="val" x="225" y="338" fill="#16a34a">5 µs</text>
+    <!-- concurrency 8 -->
+    <rect x="330" y="313.2" width="60" height="46.8" fill="#dc2626" rx="1"/>
+    <rect x="400" y="358" width="60" height="2" fill="#16a34a" rx="1"/>
+    <text class="val" x="360" y="307" fill="#dc2626">2.1 ms</text>
+    <text class="val" x="430" y="352" fill="#16a34a">9 µs</text>
+    <!-- concurrency 64 -->
+    <rect x="535" y="74.5" width="60" height="285.5" fill="#dc2626" rx="1"/>
+    <rect x="605" y="358" width="60" height="2" fill="#16a34a" rx="1"/>
+    <text class="val" x="565" y="68" fill="#dc2626">12.8 ms</text>
+    <text class="val" x="635" y="352" fill="#16a34a">42 µs</text>
+  </g>
+
+  <g class="tick" text-anchor="middle">
+    <text x="190" y="380">concurrency 1</text>
+    <text x="395" y="380">concurrency 8</text>
+    <text x="600" y="380">concurrency 64</text>
+  </g>
+  <text class="lbl" x="395" y="402" text-anchor="middle">Lower is better. With cached, microsecond-class hits queue behind in-flight misses.</text>
+
+  <!-- legend -->
+  <g font-size="13">
+    <rect x="110" y="40" width="16" height="12" fill="#dc2626" rx="2"/>
+    <text x="132" y="50" fill="#334155">cached crate (before)</text>
+    <rect x="310" y="40" width="16" height="12" fill="#16a34a" rx="2"/>
+    <text x="332" y="50" fill="#334155">moka (after)</text>
+  </g>
+
+  <text x="380" y="424" text-anchor="middle" font-size="12" fill="#94a3b8">Source: microbenchmark of the can_i host-call path, 10,000 requests, mock API server with a fixed 1 ms delay</text>
+</svg>


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Part of https://github.com/kubewarden/kubewarden.io/issues/448


Draft PR with the section and graphs for the mem growth fix.

The branch is in the kubewarden/kubewarden.io repo, feel free to close this PR and cherry-pick the commit, or add more commits here, or so.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Uploaded the raw data from the tests on the [original PR](https://github.com/kubewarden/adm-controller/pull/1952#issuecomment-5585246301).


## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
